### PR TITLE
Reverting csrf token per page bool

### DIFF
--- a/src/main/overlay/repository/conf/security/Owasp.CsrfGuard.Carbon.properties
+++ b/src/main/overlay/repository/conf/security/Owasp.CsrfGuard.Carbon.properties
@@ -137,7 +137,7 @@ org.owasp.csrfguard.UnprotectedMethods=GET
 
 # WSO2 : Considering overhead, necessity, as well as current unintended behaviour
 # of library after blocking a CSRF attack, disabling per-page tokens.
-org.owasp.csrfguard.TokenPerPage=true
+org.owasp.csrfguard.TokenPerPage=false
 org.owasp.csrfguard.TokenPerPagePrecreate=false
 
 # Token Rotation


### PR DESCRIPTION
Reverting security improvement from https://github.com/Civil-Service-Human-Resources/lpg-wso2-is/pull/12/files:
- This was causing errors on the WSO2 console when accessing a user.
- Login on lpg-services seemed to spin out on `/authenticate`.

```
[2018-03-23 12:27:28,898] ERROR {org.apache.catalina.core.ApplicationDispatcher} -  Servlet.service() for servlet bridgeservlet threw exception
java.lang.IllegalStateException: must define 'uri' attribute when token per page is enabled
	at org.owasp.csrfguard.tag.TokenValueTag.doStartTag(TokenValueTag.java:46)
```